### PR TITLE
fix: mint nft when collection does not exist

### DIFF
--- a/src/_modules_/nft/nft-solana.service.ts
+++ b/src/_modules_/nft/nft-solana.service.ts
@@ -184,9 +184,9 @@ export class NftSolanaService {
       throw new NotFoundException('Not found user!');
     }
 
-    if (!nftCollection) {
-      throw new NotFoundException('NFT Collection Not Found');
-    }
+    // if (!nftCollection) {
+    //   throw new NotFoundException('NFT Collection Not Found');
+    // }
 
     const { id: collectionId } = nftCollection;
 


### PR DESCRIPTION
Fix: not throw error when mint NFT without exist collection onchain